### PR TITLE
removed deprecated public_network_access_enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -146,7 +146,6 @@ module "aks" {
   network_contributor_role_assigned_subnet_ids      = var.network_contributor_role_assigned_subnet_ids
   only_critical_addons_enabled                      = var.only_critical_addons_enabled
   orchestrator_version                              = var.orchestrator_version
-  public_network_access_enabled                     = var.public_network_access_enabled
   public_ssh_key                                    = var.public_ssh_key
   rbac_aad_client_app_id                            = var.rbac_aad_client_app_id
   rbac_aad_server_app_id                            = var.rbac_aad_server_app_id


### PR DESCRIPTION
prompted by this warning:
╷
│ Warning: Argument is deprecated
│ 
│   with module.aks.module.aks.module.aks.azurerm_kubernetes_cluster.main,
│   on .terraform/modules/aks.aks.aks/main.tf line 37, in resource "azurerm_kubernetes_cluster" "main":
│   37:   public_network_access_enabled       = var.public_network_access_enabled
│ 
│ `public_network_access_enabled` is currently not functional and is not be passed to the API
╵

reason for deprication:
https://github.com/Azure/AKS/issues/3690#issuecomment-1590425190
