### PR TITLE
Add locals with default tags

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,33 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+locals {
+  default_tags = {
+    provisioner = "terraform"
+    resource_name = var.cluster_name
+  }
+
+  default_agents_tags = {
+    provisioner = "terraform"
+    cluster_name = var.cluster_name
+  }
+
+  agents_tags = merge(
+    local.default_agents_tags, 
+    var.agents_tags == null ? {} : var.agents_tags
+  )
+
+  tags = merge(
+    local.default_tags,
+    var.tags
+  )
+}

--- a/locals.tf
+++ b/locals.tf
@@ -12,17 +12,12 @@
 
 locals {
   default_tags = {
-    provisioner = "terraform"
+    provisioner   = "terraform"
     resource_name = var.cluster_name
   }
 
-  default_agents_tags = {
-    provisioner = "terraform"
-    cluster_name = var.cluster_name
-  }
-
   agents_tags = merge(
-    local.default_agents_tags, 
+    local.default_tags,
     var.agents_tags == null ? {} : var.agents_tags
   )
 

--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ module "aks" {
   agents_availability_zones    = var.agents_availability_zones
   agents_size                  = var.agents_size
   agents_labels                = var.agents_labels
-  agents_tags                  = var.agents_tags
+  agents_tags                  = local.agents_tags
   agents_type                  = var.agents_type
   agents_taints                = var.agents_taints
   agents_pool_max_surge        = var.agents_pool_max_surge
@@ -162,6 +162,6 @@ module "aks" {
   temporary_name_for_rotation                       = var.temporary_name_for_rotation
   ultra_ssd_enabled                                 = var.ultra_ssd_enabled
 
-  tags = var.tags
+  tags = local.tags
 
 }


### PR DESCRIPTION
Addressed the cluster tags and tags for agents. Probably needs another pass to figure out tagging on the node pools objects.